### PR TITLE
中文匹配//gn 修改为 //n, 添加了中文与标点符号总数 CW

### DIFF
--- a/plugin/wc.vim
+++ b/plugin/wc.vim
@@ -12,9 +12,12 @@ endif
 function! s:CountCEWords() range
     try
         let l:ccount = split(execute(a:firstline . "," . a:lastline
-                    \ . "s/[\u4e00-\u9fa5\u3040-\u30FF]//gn"))[0]
+                    \ . "s/[\u4e00-\u9fa5\u3040-\u30FF]//n"))[0]
+        let l:cwcount = split(execute(a:firstline . "," . a:lastline
+                    \ . "s/[\u4e00-\u9fa5\u3002\uFF1F\uFF01\u3010\u3011\uFF0C\u3001\uFF1B\uFF1A\u300C\u300D\u300E\u300F\u2019\u201C\u201D\u2018\uFF08\uFF09\u3014\u3015\u2026\u2013\uFF0E\u2014\u300A\u300B\u3008\u3009]//n"))[0]
     catch
         let l:ccount = "0"
+        let l:cwcount = "0"
     endtry
     let l:stdin = join(getline(a:firstline, a:lastline), "\n")
     if &filetype != "tex"
@@ -25,7 +28,7 @@ function! s:CountCEWords() range
                     \ . "python3 " . shellescape(s:stripwchar),
                     \ l:stdin)))
     endif
-    echo "C " . l:ccount . " E " . l:ecount
+    echo "C " . l:ccount . " CW " . l:cwcount . " E " . l:ecount
 endfunction
 
 command! -range=% -bar Wc


### PR DESCRIPTION
我的 vim 版本为 
VIM - Vi IMproved 8.2 (2019 Dec 12, compiled Jul 11 2021 17:44:18)
macOS version - x86_64
中文匹配//gn 在 该版本下无法得到正确结果，修改为 //n 可得到；考虑到中文统计一般会加上标点，添加了 CW 中文标点统计。